### PR TITLE
Fix link to config article in FAQ, update copyright

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -20,7 +20,7 @@
     </div>
     <footer>
         <div class="copyright">
-            © NikGApps - 2020
+            © 2022 NikGApps
         </div>
     </footer>
 </div>

--- a/faqs.html
+++ b/faqs.html
@@ -153,7 +153,7 @@ bClass: faqs
                         you
                         like.
                         You can skip any Package that you don't want to be part of your installation.
-                        More on that <a style="color:blue" href="https://nikgapps.com/misc/2020/11/22/NikGapps-Config.html">here</a>
+                        More on that <a style="color:blue" href="https://nikgapps.com/misc/2022/02/22/NikGapps-Config.html">here</a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
Old link produces 404.

Updated year in copyright string and use more common format for it.

Signed-off-by: Yurii Kolesnykov <root@yurikoles.com>
